### PR TITLE
Fix Node 0.10

### DIFF
--- a/lib/spec-resolver.js
+++ b/lib/spec-resolver.js
@@ -28,7 +28,7 @@ exports.resolveSpec = function resolveSpec(connector, cb) {
     }
 
     // check for .json or .yaml, read the spec file and parse spec object
-    var parsedPath = path.parse(self.spec);
+    var parsedPath = path.extname(self.spec);
     // TODO: @gunjpan: resolve the path against project root instead of cwd
     var specPath = path.resolve(process.cwd(), self.spec);
 


### PR DESCRIPTION
* use `path.extname` instead of `path.parse`

Connect to https://github.com/strongloop-internal/scrum-loopback/issues/1058

/to: @rmg @superkhau 
/cc: @bajtos 