### PR TITLE
Use path.extname instead of path.parse

### DIFF
--- a/lib/spec-resolver.js
+++ b/lib/spec-resolver.js
@@ -28,11 +28,11 @@ exports.resolveSpec = function resolveSpec(connector, cb) {
     }
 
     // check for .json or .yaml, read the spec file and parse spec object
-    var parsedPath = path.parse(self.spec);
+    var ext = path.extname(self.spec);
     // TODO: @gunjpan: resolve the path against project root instead of cwd
     var specPath = path.resolve(process.cwd(), self.spec);
 
-    switch (parsedPath.ext) {
+    switch (ext) {
       case '.json':
         fs.readFile(specPath, function(err, data) {
           if (err) return cb(err, null);


### PR DESCRIPTION
* Use `path.extname` instead of `path.parse`

Connect to https://github.com/strongloop-internal/scrum-loopback/issues/1058

/to: @rmg @bajtos 
/cc: @superkhau 