### PR TITLE
Enable dual callback/promise mode on model methods

### DIFF
--- a/lib/swagger-connector.js
+++ b/lib/swagger-connector.js
@@ -231,13 +231,15 @@ SwaggerConnector.prototype._methodName =
 
 function createCallbackWrapper(method) {
   function wrapper() {
-    var args = [];
-    var fn = method;
+    const args = new Array(arguments.length);
+    // do not call Array.prototype.slice on arguments
+    // to avoid deoptimization of this method by V8
+    let ix;
+    for (ix = 0; ix < arguments.length; ix++) {
+      args[ix] = arguments[ix];
+    }
 
     if (arguments.length) {
-      args = arguments.length === 1 ?
-        [arguments[0]] : Array.apply(null, arguments);
-
       var cb;
       var success = function(res) {
         cb(null, res);
@@ -256,7 +258,7 @@ function createCallbackWrapper(method) {
         args.push(failure);
       }
     }
-    return fn.apply(this, args);
+    return method.apply(this, args);
   }
   return wrapper;
 }

--- a/lib/swagger-connector.js
+++ b/lib/swagger-connector.js
@@ -14,6 +14,8 @@ var SpecResolver = require('./spec-resolver');
 var VERSION = require('../package.json').version;
 var SwaggerClient = require('swagger-client');
 
+const Promise = require('bluebird');
+
 /**
  * Export the initialize method to loopback-datasource-juggler
  * @param {DataSource} dataSource The dataSource object
@@ -237,6 +239,20 @@ function createCallbackWrapper(method) {
     let ix;
     for (ix = 0; ix < arguments.length; ix++) {
       args[ix] = arguments[ix];
+    }
+
+    const lastArg = args.length ? args[args.length - 1] : undefined;
+    const isPromiseMode = !args.length ||
+      typeof lastArg !== 'function';
+    const isMockMode = typeof lastArg === 'object' && lastArg.mock;
+
+    if (isPromiseMode && !isMockMode) {
+      return new Promise((resolve, reject) => {
+        args.push(resolve);
+        args.push(reject);
+        // "this" is preserved via the arrow function
+        method.apply(this, args);
+      });
     }
 
     if (arguments.length) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "posttest": "npm run lint"
   },
   "dependencies": {
+    "bluebird": "^3.4.7",
     "debug": "^2.2.0",
     "js-yaml": "^3.6.0",
     "swagger-client": "^2.1.13",

--- a/test/test-connector.js
+++ b/test/test-connector.js
@@ -100,7 +100,19 @@ describe('swagger connector', function() {
           done();
         });
       });
+
+      it('supports model methods returning a Promise', done => {
+        var PetService = ds.createModel('PetService', {});
+        PetService.getPetById({petId: 1}).then(
+          function onSuccess(res) {
+            res.should.have.property('status', 200);
+            done();
+          },
+          /* on error */ done
+        );
+      });
     });
+
     // out of scope of initial release
     describe.skip('models with remotingEnabled', function() {
       let ds;
@@ -164,6 +176,26 @@ describe('swagger connector', function() {
         events.push('after execute');
         next();
       });
+      PetService.getPetById({petId: 1}, function(err, response) {
+        assert.deepEqual(events, ['before execute', 'after execute']);
+        done();
+      });
+    });
+
+    it('supports Promise-based connector-hooks', done => {
+      const events = [];
+      const connector = ds.connector;
+
+      connector.observe('before execute', ctx => {
+        events.push('before execute');
+        return Promise.resolve();
+      });
+
+      connector.observe('after execute', ctx => {
+        events.push('after execute');
+        return Promise.resolve();
+      });
+
       PetService.getPetById({petId: 1}, function(err, response) {
         assert.deepEqual(events, ['before execute', 'after execute']);
         done();


### PR DESCRIPTION
### Description

The first commit cleans up argument handling in preparation for the actual changes. See also https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments

The second commit implements the actual feature:

When the method arguments do not provide any callback argument,
then return a promise that will be resolved/rejected with the operation
outcome.

Also correctly handle the case when the last argument is an options
object enabling the mock mode - in such case the result of the operation
is returned directly.

While swagger-client does support Promise natively, it requires a configuration at SwaggerClient level, which is IMO impractical in LoopBack - the code depending on Promise API would become tightly coupled with datasource configuration enabling the Promise mode.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
