### PR TITLE
Simple caching for GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,62 @@ With JSON in `datasources.json` (for example, with basic authentication):
 }
 ```
 
+### Caching
+
+As an experimental feature, loopback-connector-swagger is able to cache the result of `GET` requests.
+
+**Important: we support only one cache invalidation mechanism - expiration based on a static TTL value.**
+
+To enable caching, you need to specify:
+
+ - `cache.model` (required) - name of the model providing access to the cache.
+   The model should be extending loopback's built-in `KeyValueModel`
+   and be attached to one of key-value datasources (e.g. Redis or
+   eXtremeScale).
+
+ - `cache.ttl` (required) - time to live for cache entries, the value
+   is in milliseconds. Note that certain cache implementations (notably
+   eXtremeScale) do not support sub-second precision for TTL.
+
+#### Example configuration
+
+`server/datasources.json`
+
+```json
+{
+  "SwaggerDS": {
+    "connector": "swagger",
+    "cache": {
+      "model": "SwaggerCache",
+      "ttl": 100
+    }
+  },
+  "cache": {
+    "connector": "kv-redis",
+  }
+}
+```
+
+`common/models/swagger-cache.json`
+
+```
+{
+  "name": "SwaggerCache",
+  "base": "KeyValueModel",
+  // etc.
+}
+```
+
+`server/model-config.json`
+```
+{
+  "SwaggerCache": {
+    "dataSource": "cache",
+    "public": false
+  }
+}
+```
+
 ## Data source properties
 
 Specify the options for the data source with the following properties.

--- a/lib/swagger-connector.js
+++ b/lib/swagger-connector.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const assert = require('assert');
 var fs = require('fs');
 var path = require('path');
 var url = require('url');
@@ -13,6 +14,7 @@ var oAuth = require('./oAuth');
 var SpecResolver = require('./spec-resolver');
 var VERSION = require('../package.json').version;
 var SwaggerClient = require('swagger-client');
+const qs = require('querystring');
 
 const Promise = require('bluebird');
 
@@ -24,6 +26,12 @@ const Promise = require('bluebird');
 
 exports.initialize = function initializeDataSource(dataSource, callback) {
   var settings = dataSource.settings || {};
+
+  if (settings.cache) {
+    assert(settings.cache.model, '"cache.model" setting is required');
+    assert(!!settings.cache.ttl, '"cache.ttl" setting is required');
+    assert(settings.cache.ttl > 0, '"cache.ttl" must be a positive number');
+  }
 
   var connector = new SwaggerConnector(settings);
 
@@ -42,6 +50,7 @@ function SwaggerConnector(settings) {
 
   this.settings = settings;
   this.spec = settings.spec;
+  this.cache = settings.cache;
   this.connectorHooks = new ConnectorHooks();
 
   if (debug.enabled) {
@@ -179,7 +188,7 @@ SwaggerConnector.prototype.setupDataAccessObject = function() {
       var methodName = this._methodName(a, o, this.DataAccessObject);
 
       if (debug.enabled) {
-        debug('Adding method: %s %s ', a, o);
+        debug('Adding method api=%s operation=%s as %s', a, o, methodName);
       }
 
       var wrapper = createCallbackWrapper(method);
@@ -250,6 +259,12 @@ function createCallbackWrapper(method) {
       args[ix] = arguments[ix];
     }
 
+    if (!args.length) {
+      // the caller did not provide any operation parameters to use
+      // add an empty object as the params to satisfy swagger-client API
+      args.push({});
+    }
+
     const lastArg = args.length ? args[args.length - 1] : undefined;
     const isPromiseMode = !args.length ||
       typeof lastArg !== 'function';
@@ -293,23 +308,32 @@ SwaggerConnector.prototype.setupConnectorHooks = function() {
   var self = this;
   self.connectorHooks.beforeExecute.apply = function(obj) {
     obj.headers['User-Agent'] = 'loopback-connector-swagger/' + VERSION;
-    obj.beforeSend = function(cb) {
-      var ctx = {req: obj};
-      self.notifyObserversOf('before execute', ctx, function(err) {
-        if (err) return cb(err);
 
-        cb(ctx.req);
-      });
-    };
     var cbSuccess = obj.on.response;
     var cbError = obj.on.error;
 
+    obj.beforeSend = function(cb) {
+      var ctx = {req: obj};
+      self.notifyObserversOf('before execute', ctx, function(err) {
+        if (err) return cbError(err);
+        obj = ctx.req;
+        self._checkCache(obj, function(err, cachedResponse) {
+          if (err) return cbError(err);
+          if (cachedResponse)
+            return cbSuccess(cachedResponse);
+          cb(obj);
+        });
+      });
+    };
     obj.on.response = function(data) {
       var ctx = {res: data};
       self.notifyObserversOf('after execute', ctx, function(err) {
         if (err) return cbError(err);
-
-        cbSuccess(ctx.res);
+        data = ctx.res;
+        self._updateCache(obj, data, function(err) {
+          if (err) cbError(err);
+          else cbSuccess(data);
+        });
       });
     };
 
@@ -322,6 +346,70 @@ SwaggerConnector.prototype.setupConnectorHooks = function() {
 
     return obj;
   };
+};
+
+SwaggerConnector.prototype._checkCache = function(req, cb) {
+  const Cache = this._getCacheModel();
+  if (!Cache) return cb();
+
+  const key = this._getCacheKey(req);
+  if (!key) return cb();
+
+  Cache.get(key, (err, value) => {
+    if (err)
+      return cb(err);
+    if (!value)
+      return cb();
+
+    debug('Returning cached response for %s', key);
+    return req.on.response(value);
+  });
+};
+
+SwaggerConnector.prototype._updateCache = function(req, res, cb) {
+  const Cache = this._getCacheModel();
+  if (!Cache) return cb();
+
+  const key = this._getCacheKey(req);
+  if (!key) return cb();
+
+  Cache.set(key, res, {ttl: this.settings.cache.ttl}, cb);
+};
+
+SwaggerConnector.prototype._getCacheKey = function(req) {
+  if (req.method.toLowerCase() !== 'get')
+    return null;
+
+  const base = req.url.replace(/^[^:]+:\/\/[^\/]+/, '');
+  const headers = qs.stringify(req.headers);
+  return base + ';' + headers;
+};
+
+SwaggerConnector.prototype._getCacheModel = function() {
+  if (!this.cache) return null;
+  let Model = this.cache.model;
+  if (typeof Model === 'function' || Model === null)
+    return Model;
+
+  const modelName = Model;
+  Model = this.dataSource.modelBuilder.getModel(modelName);
+  if (!Model) {
+    // NOTE(bajtos) Unfortunately LoopBack does not propagate the datasource
+    // name used in the app registry down to the DataSource object
+    // As a workaround, we can use Swagger service name and URL instead
+    const title = this.client.info && this.client.info.title;
+    const url = this.client.scheme + '://' + this.client.host + '/' +
+      this.client.basePath;
+    const name = title ? `"${title}" (${url})` : url;
+
+    console.warn(
+      'Model %j not found, caching is disabled for Swagger datasource %s',
+      modelName, name);
+    Model = null;
+  }
+
+  this.cache.model = Model;
+  return Model;
 };
 
 /**

--- a/lib/swagger-connector.js
+++ b/lib/swagger-connector.js
@@ -207,6 +207,15 @@ SwaggerConnector.prototype.setupDataAccessObject = function() {
 };
 
 /**
+ * Hook for defining a model by the data source
+ * @param {object} modelDef The model description
+ */
+SwaggerConnector.prototype.define = function(modelDef) {
+  const modelName = modelDef.model.modelName;
+  this._models[modelName] = modelDef;
+};
+
+/**
  * Find or derive the method name from apiName/operationName
  * @param {String} apiName The api name
  * @param {String} operationName The api operation name

--- a/test/fixtures/echo-service.js
+++ b/test/fixtures/echo-service.js
@@ -1,0 +1,37 @@
+// Copyright IBM Corp. 2016,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const fs = require('fs');
+const loopback = require('loopback');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const app = loopback({localRegistry: true});
+module.exports = app;
+
+const specFile = path.join(__dirname, 'echo-service.yaml');
+const spec = yaml.safeLoad(fs.readFileSync(specFile));
+
+app.get('/swagger', (req, res) => res.json(spec));
+app.get('/echo', (req, res) => res.json({
+  message: req.query.message || 'Hello World!',
+  language: req.headers['accept-language'] || 'en',
+  timestamp: now(),
+}));
+
+app.post('/uids', (req, res) => res.json({id: String(now())}));
+
+function now() {
+  const tick = process.hrtime();
+  return tick[0] * 1e9 + tick[1];
+}
+
+if (require.main === module) {
+  app.listen(4000, () => {
+    console.log('Listening at http://127.0.0.1:4000/');
+  });
+}

--- a/test/fixtures/echo-service.yaml
+++ b/test/fixtures/echo-service.yaml
@@ -1,0 +1,51 @@
+swagger: "2.0"
+info:
+  title: Echo Service
+  description: This is a sample echo service.
+  version: "1.0.0"
+paths:
+  /echo:
+    get:
+      summary: Echo back the message
+      operationId: echo
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        -
+          name: message
+          in: query
+          description: The message to echo back.
+          required: false
+          type: string
+        -
+          name: Accept-Language
+          in: header
+          description: Specify the user's language
+          required: false
+          type: string
+      responses:
+        200:
+          description: Success response
+          schema:
+            type: 'object'
+            properties:
+              message:
+                type: string
+              language:
+                type: string
+              timestamp:
+                type: integer
+  /uids:
+    post:
+      summary: Create a new unique ID value
+      operationId: createId
+      responses:
+        200:
+          description: Success response
+          schema:
+            type: 'object'
+            properties:
+              id:
+                type: string

--- a/test/test-caching.js
+++ b/test/test-caching.js
@@ -1,0 +1,123 @@
+// Copyright IBM Corp. 2016,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const echoService = require('./fixtures/echo-service');
+const loopback = require('loopback');
+const Promise = require('bluebird');
+const should = require('should/as-function');
+
+const CACHE_TTL = 100; // milliseconds
+
+describe('swagger connector with caching', () => {
+  let app, echoUrl, EchoClient, Cache;
+  beforeEach(setupEchoService);
+  beforeEach(setupApp);
+  beforeEach(setupClientModel);
+  beforeEach(setupCache);
+
+  it('returns fresh data on the first request', () => {
+    return EchoClient.echo({
+      message: 'hello',
+      'accept-language': 'en',
+    }).then(res => {
+      should(res).have.property('status', 200);
+      should(res.obj).containDeep({
+        'message': 'hello',
+        'language': 'en',
+      });
+    });
+  });
+
+  it('returns cached data on the second request', () => {
+    return EchoClient.echo()
+      .then(first => EchoClient.echo().then(second => [first, second]))
+      .spread((first, second) => {
+        should(first).deepEqual(second);
+      });
+  });
+
+  it('includes query parameters in the cache key', () => {
+    return EchoClient.echo({message: 'one'})
+      .then(() => EchoClient.echo({message: 'second'}))
+      .then(res => {
+        should(res.obj).containDeep({message: 'second'});
+      });
+  });
+
+  it('includes header parameters in the cache key', () => {
+    return EchoClient.echo({'accept-language': 'en'})
+      .then(() => EchoClient.echo({'accept-language': 'cs'}))
+      .then(res => {
+        should(res.obj).containDeep({language: 'cs'});
+      });
+  });
+
+  it('does not cache non-GET requests', () => {
+    return EchoClient.createId()
+      .then(first => EchoClient.createId().then(second => [first, second]))
+      .spread((first, second) => {
+        should(second.obj.id).not.equal(first.obj.id);
+      });
+  });
+
+  it('honours TTL setting', () => {
+    let first;
+    return EchoClient.echo()
+      .then(r => first = r)
+      .delay(2 * CACHE_TTL)
+      .then(() => EchoClient.echo())
+      .then(second => {
+        should(second.obj.timestamp).not.equal(first.obj.timestamp);
+      });
+  });
+
+  function setupEchoService(done) {
+    echoService
+      .listen(0, function() {
+        echoUrl = 'http://127.0.0.1:' + this.address().port;
+        done();
+      })
+      .once('error', done);
+  }
+
+  function setupApp() {
+    app = loopback({localRegistry: true, loadBuiltinModels: true});
+  }
+
+  function setupCache(done) {
+    const ds = app.dataSource('echo-cache', {connector: 'kv-memory'});
+    Cache = app.registry.createModel({
+      name: 'EchoCache',
+      base: 'KeyValueModel',
+    });
+    app.model(Cache, {dataSource: 'echo-cache'});
+    waitForDsConnect(ds, done);
+  }
+
+  function setupClientModel(done) {
+    const ds = app.dataSource('echo-service', {
+      connector: require('../index'),
+      spec: echoUrl + '/swagger',
+      validate: true,
+      cache: {
+        model: 'EchoCache',
+        ttl: CACHE_TTL,
+      },
+    });
+    EchoClient = app.registry.createModel({
+      name: 'Echo',
+      base: 'Model',
+    });
+    app.model(EchoClient, {dataSource: 'echo-service'});
+    waitForDsConnect(ds, done);
+  }
+
+  function waitForDsConnect(ds, done) {
+    ds.once('connected', () => done());
+    ds.once('error', done);
+  }
+});

--- a/test/test-connector.js
+++ b/test/test-connector.js
@@ -132,6 +132,17 @@ describe('swagger connector', function() {
         done();
       });
     });
+
+    it('allows models to be attached before the spec is loaded', done => {
+      const ds = createDataSource('test/fixtures/petStore.json');
+      const PetService = ds.createModel('PetService', {});
+
+      ds.once('connected', () => {
+        should(Object.keys(PetService)).containEql('getPetById');
+        should(typeof PetService.getPetById).eql('function');
+        done();
+      });
+    });
   });
 
   describe('Swagger invocations', function() {


### PR DESCRIPTION
### Description

Implement a basic caching feature for GET requests:
 - Use KeyValueModel to access the cache
 - Cache entries are invalidated via time-to-live setting

The caching is enabled by adding a `cache` section to the datasource configuration, for example:

```json
{
  "SwaggerDS": {
    "connector": "swagger",
    "cache": {
      "model": "SwaggerCache",
      "ttl": 100
    }
  },
  "cache": {
    "connector": "kv-redis",
  }
}
```

(The `SwaggerCache` model in the example above is extending `KeyValueModel` and attached to `cache` datasource.)