### PR TITLE
chore: update swagger-client dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bluebird": "^3.4.7",
     "debug": "^2.2.0",
     "js-yaml": "^3.6.0",
-    "swagger-client": "^2.1.13",
+    "swagger-client": "^3.0.1",
     "swagger-parser": "^3.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
update swagger-client dependencies to ^3.0.1