### PR TITLE
Update license for consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
- - 4
  - 6
+ - 8
+ - 10
+ 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2012,2017. All Rights Reserved.
+Copyright (c) IBM Corp. 2012,2018. All Rights Reserved.
 Node module: loopback-connector-swagger
 This project is licensed under the MIT License, full text below.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,10 @@
-The MIT License (MIT)
+Copyright (c) IBM Corp. 2012,2017. All Rights Reserved.
+Node module: loopback-connector-swagger
+This project is licensed under the MIT License, full text below.
 
-Copyright (c) 2016 StrongLoop
+--------
+
+MIT license
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,13 +13,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
-// Node module: loopback
+// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Node module: loopback-connector-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/lib/oAuth.js
+++ b/lib/oAuth.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
-// Node module: loopback
+// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Node module: loopback-connector-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/lib/spec-resolver.js
+++ b/lib/spec-resolver.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
-// Node module: loopback
+// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Node module: loopback-connector-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/lib/swagger-connector.js
+++ b/lib/swagger-connector.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
-// Node module: loopback
+// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Node module: loopback-connector-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.2.0",
   "description": "Connect Loopback to a Swagger-compliant API",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,5 +29,6 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-connector-swagger.git"
   },
-  "license": "SEE LICENSE IN LICENSE.md"
+  "copyright.owner": "IBM Corp.",
+  "license": "MIT"
 }

--- a/test/fixtures/echo-service.js
+++ b/test/fixtures/echo-service.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2016,2018. All Rights Reserved.
 // Node module: loopback-connector-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/fixtures/echo-service.js
+++ b/test/fixtures/echo-service.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
-// Node module: loopback
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: loopback-connector-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/fixtures/petStore.js
+++ b/test/fixtures/petStore.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
-// Node module: loopback
+// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Node module: loopback-connector-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/test-caching.js
+++ b/test/test-caching.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2016,2018. All Rights Reserved.
 // Node module: loopback-connector-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/test-caching.js
+++ b/test/test-caching.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
-// Node module: loopback
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: loopback-connector-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/test-connector-auth.js
+++ b/test/test-connector-auth.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
-// Node module: loopback
+// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Node module: loopback-connector-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/test-connector.js
+++ b/test/test-connector.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
-// Node module: loopback
+// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Node module: loopback-connector-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/test-oAuth.js
+++ b/test/test-oAuth.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
-// Node module: loopback
+// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Node module: loopback-connector-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/test-spec-resolver.js
+++ b/test/test-spec-resolver.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
-// Node module: loopback
+// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Node module: loopback-connector-swagger
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 


### PR DESCRIPTION
### Description
- Update the license to make "IBM copyright" instead of "StrongLoop copyright" for being consistent with the other modules
- update `package.json` to the right value for `slt copyright` command to run properly
- run `slt copyright` to update the copyright header of source code

Related to: https://github.com/strongloop-internal/scrum-apex/issues/382